### PR TITLE
Remove zookeeper_server_list from collector config

### DIFF
--- a/devstack/lib/contrail_config
+++ b/devstack/lib/contrail_config
@@ -233,7 +233,6 @@ function contrail_config_collector()
     iniset -sudo $config_file DEFAULT hostname $CONTRAIL_HOSTNAME
 
     iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_IP_PORT_LIST
-    iniset -sudo $config_file DEFAULT zookeeper_server_list $ZOOKEEPER_IP_PORT_LIST
 
     iniset -sudo $config_file DISCOVERY server $DISCOVERY_IP
     iniset -sudo $config_file DISCOVERY port 5998


### PR DESCRIPTION
Zookeeper is not used by collector.

Collector doesn't start with this in the config file.