### PR TITLE
Add _vercmp function to compare release

### DIFF
--- a/devstack/lib/contrail_config
+++ b/devstack/lib/contrail_config
@@ -49,6 +49,44 @@ function _fill_certificate_options()
     fi
 }
 
+function _vercmp()
+{
+    local v1=$1
+    local op=$2
+    local v2=$3
+    local result
+
+    # sort the two numbers with sort's "-V" argument.  Based on if v2
+    # swapped places with v1, we can determine ordering.
+    result=$(echo -e "$v1\n$v2" | sort -V | head -1)
+
+    case $op in
+        "==")
+            [ "$v1" = "$v2" ]
+            return
+            ;;
+        ">")
+            [ "$v1" != "$v2" ] && [ "$result" = "$v2" ]
+            return
+            ;;
+        "<")
+            [ "$v1" != "$v2" ] && [ "$result" = "$v1" ]
+            return
+            ;;
+        ">=")
+            [ "$result" = "$v2" ]
+            return
+            ;;
+        "<=")
+            [ "$result" = "$v1" ]
+            return
+            ;;
+        *)
+            die $LINENO "unrecognised op: $op"
+            ;;
+    esac
+}
+
 function contrail_config_cassandra()
 {
     sudo sed -i "s/^\#MAX_HEAP_SIZE=.*/MAX_HEAP_SIZE=\"$CASS_MAX_HEAP_SIZE\"/" /etc/cassandra/cassandra-env.sh
@@ -235,7 +273,7 @@ function contrail_config_collector()
     iniset -sudo $config_file DEFAULT hostip $COLLECTOR_IP
     iniset -sudo $config_file DEFAULT hostname $CONTRAIL_HOSTNAME
 
-    if vercmp $CONTRAIL_BRANCH "<" R3.0; then
+    if _vercmp $CONTRAIL_BRANCH "<" R3.0; then
         iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_IP_PORT_LIST
     else
         iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_CQL_IP_PORT_LIST
@@ -260,7 +298,7 @@ function contrail_config_analytics_api()
     #REVISIT: analytics api currently fails with default value (15)
     iniset -sudo $config_file DEFAULT partitions 0
 
-    if vercmp $CONTRAIL_BRANCH "<" R3.0; then
+    if _vercmp $CONTRAIL_BRANCH "<" R3.0; then
         iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_IP_PORT_LIST
     else
         iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_CQL_IP_PORT_LIST
@@ -280,7 +318,7 @@ function contrail_config_query()
     iniset -sudo $config_file DEFAULT hostip $COLLECTOR_IP
     iniset -sudo $config_file DEFAULT hostname $CONTRAIL_HOSTNAME
 
-    if vercmp $CONTRAIL_BRANCH "<" R3.0; then
+    if _vercmp $CONTRAIL_BRANCH "<" R3.0; then
         iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_IP_PORT_LIST
     else
         iniset -sudo $config_file DEFAULT cassandra_server_list $CASSANDRA_CQL_IP_PORT_LIST

--- a/devstack/lib/contrail_config
+++ b/devstack/lib/contrail_config
@@ -49,44 +49,6 @@ function _fill_certificate_options()
     fi
 }
 
-function _vercmp()
-{
-    local v1=$1
-    local op=$2
-    local v2=$3
-    local result
-
-    # sort the two numbers with sort's "-V" argument.  Based on if v2
-    # swapped places with v1, we can determine ordering.
-    result=$(echo -e "$v1\n$v2" | sort -V | head -1)
-
-    case $op in
-        "==")
-            [ "$v1" = "$v2" ]
-            return
-            ;;
-        ">")
-            [ "$v1" != "$v2" ] && [ "$result" = "$v2" ]
-            return
-            ;;
-        "<")
-            [ "$v1" != "$v2" ] && [ "$result" = "$v1" ]
-            return
-            ;;
-        ">=")
-            [ "$result" = "$v2" ]
-            return
-            ;;
-        "<=")
-            [ "$result" = "$v1" ]
-            return
-            ;;
-        *)
-            die $LINENO "unrecognised op: $op"
-            ;;
-    esac
-}
-
 function contrail_config_cassandra()
 {
     sudo sed -i "s/^\#MAX_HEAP_SIZE=.*/MAX_HEAP_SIZE=\"$CASS_MAX_HEAP_SIZE\"/" /etc/cassandra/cassandra-env.sh

--- a/devstack/lib/functions
+++ b/devstack/lib/functions
@@ -1,0 +1,44 @@
+#!/bin/bash
+# functions - Devstack utilities (override)
+
+# vercmp ver1 op ver2
+#  Compare VER1 to VER2
+#   - op is one of < <= == >= >
+#   - returns true if satisified
+function _vercmp()
+{
+    local v1=$1
+    local op=$2
+    local v2=$3
+    local result
+
+    # sort the two numbers with sort's "-V" argument.  Based on if v2
+    # swapped places with v1, we can determine ordering.
+    result=$(echo -e "$v1\n$v2" | sort -V | head -1)
+
+    case $op in
+        "==")
+            [ "$v1" = "$v2" ]
+            return
+            ;;
+        ">")
+            [ "$v1" != "$v2" ] && [ "$result" = "$v2" ]
+            return
+            ;;
+        "<")
+            [ "$v1" != "$v2" ] && [ "$result" = "$v1" ]
+            return
+            ;;
+        ">=")
+            [ "$result" = "$v2" ]
+            return
+            ;;
+        "<=")
+            [ "$result" = "$v1" ]
+            return
+            ;;
+        *)
+            die $LINENO "unrecognised op: $op"
+            ;;
+    esac
+}

--- a/devstack/override-defaults
+++ b/devstack/override-defaults
@@ -8,3 +8,4 @@ Q_L3_ROUTER_PER_TENANT=${Q_L3_ROUTER_PER_TENANT:-True}
 # devstack calls has_neutron_plugin_security_group before settings are sourced
 CONTRAIL_PLUGIN_DIR="$dir/devstack"
 source $CONTRAIL_PLUGIN_DIR/lib/neutron_plugins/opencontrail
+source $CONTRAIL_PLUGIN_DIR/lib/functions


### PR DESCRIPTION
Hi zioc,
I was targeting contrail R2.21.x with openstack stable/liberty.
Since I got errors with the collector which didn't start because it didn't support the zookeeper field in its config file. And you took that in account in the devstack/lib/contrail_config file, where you used vercmp in a conditionnal statement to do this. But vercmp is only available since stable/mitaka there is another version of vercmp in stable/liberty called vercmp_numbers which is not working the same way.

I know that your support since stable/mitaka. But it could be a first commit to support the stable/liberty release. So if you want to create such a branch let me know ;)

Commit message
##############
Given that the version of this function is only available in the
devstack since stable/mitaka.
It replace the vercmp_numbers function of stable/liberty which works not
the same way.
It could be a good way to already get this function hard-coded the
contrail-devstack-plugin to work correctly with stable/liberty
Also it is possible to use devstack stable/liberty with some old versions of
opencontrail (<R3.0)