### PR TITLE
Don't dowload, patch and install lib ipfix

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -316,6 +316,8 @@ elif [[ "$1" == "stack" && "$2" == "pre-install" ]]; then
         # TODO(ethuleau): Don't install fabric package due to bug
         # https://bugs.launchpad.net/juniperopenstack/+bug/1757518
         sed -ie "/fabric-ansible/ s/^/#/" controller/src/config/SConscript
+        # Don't download, patch and build ipfix lib from third-party package
+        sed -ie "/ipfix/ s/^/#/" controller/lib/SConscript
         sudo -E scons $SCONS_ARGS
         cd $TOP_DIR
 


### PR DESCRIPTION
Don't use the third party tool to install lib ipfix as it fails to build
it and continue to install it from the Contrail repo.