### PR TITLE
Remove vnc_api lib dependency

### DIFF
--- a/devstack/files/requirements.txt
+++ b/devstack/files/requirements.txt
@@ -36,6 +36,4 @@ sandesh-common
 sseclient
 stevedore
 thrift==0.9.3
-vnc_api
 xmltodict
-


### PR DESCRIPTION
The python package vnc_api was renamed contrail-api-client since release
5.0. Remove it as devstack plugin dependency as not used by devstack.