### PR TITLE
Add RBAC configuration knobs

### DIFF
--- a/devstack/lib/contrail_config
+++ b/devstack/lib/contrail_config
@@ -85,6 +85,7 @@ function contrail_config_cassandra()
     stop_service cassandra || true
     sudo rm -Rf /var/lib/cassandra/*
     start_service cassandra
+    timeout $SERVICE_TIMEOUT sh -c "while ! nc -z $APISERVER_IP 9160; do sleep 1; done" || die $LINENO "cassandra thrift API did not start"
 }
 
 function contrail_config_zookeeper()
@@ -124,9 +125,11 @@ function contrail_config_api()
         iniset -sudo $config_file DEFAULTS ifmap_password 'api-server'
     fi
 
-    iniset -sudo $config_file DEFAULTS multi_tenancy $MULTI_TENANCY
-    iniset -sudo $config_file DEFAULTS multi_tenancy_with_rbac $MULTI_TENANCY
     iniset -sudo $config_file DEFAULTS auth keystone
+    iniset -sudo $config_file DEFAULTS aaa_mode $AAA_MODE
+    if [[ $AAA_MODE != 'no-auth' ]]; then
+        iniset -sudo $config_file DEFAULTS global_read_only_role service
+    fi
 
     if _vercmp $CONTRAIL_BRANCH "<" R4.0; then
         iniset -sudo $config_file DEFAULTS disc_server_ip $DISCOVERY_IP
@@ -199,9 +202,7 @@ function contrail_config_svc_monitor()
     fi
 
     iniset -sudo $config_file SCHEDULER analytics_server_list "$ANALYTICS_IP_PORT_LIST"
-    if [[ "$MULTI_TENANCY" == "False" ]]; then
-        iniset -sudo $config_file SCHEDULER aaa_mode no-auth
-    fi
+    iniset -sudo $config_file SCHEDULER aaa_mode $AAA_MODE
 
     iniset -sudo $config_file DEFAULTS cassandra_server_list "$CASSANDRA_IP_PORT_LIST"
     iniset -sudo $config_file DEFAULTS zk_server_ip "$ZOOKEEPER_IP_LIST"
@@ -242,11 +243,10 @@ function contrail_config_api_lib()
 
     iniset -sudo $config_file global WEB_SERVER $APISERVER_IP
     iniset -sudo $config_file global WEB_PORT 8082
-    iniset -sudo $config_file global BASE_URL  '/'
+    iniset -sudo $config_file global BASE_URL '/'
 
-    iniset -sudo $config_file auth AUTHN_TYPE  'keystone'
-    iniset -sudo $config_file auth AUTHN_PORT  5000
-    iniset -sudo $config_file auth AUTHN_SERVER $KEYSTONE_AUTH_HOST
+    iniset -sudo $config_file auth AUTHN_TYPE 'keystone'
+    iniset -sudo $config_file auth AUTHN_TOKEN_URL "${KEYSTONE_SERVICE_URI}/v3/auth/tokens"
 }
 
 function contrail_config_control()
@@ -325,10 +325,7 @@ function contrail_config_analytics_api()
         iniset -sudo $config_file DEFAULT cassandra_server_list "$CASSANDRA_IP_PORT_LIST"
     else
         iniset -sudo $config_file DEFAULT cassandra_server_list "$CASSANDRA_CQL_IP_PORT_LIST"
-
-        if [[ "$MULTI_TENANCY" == "False" ]]; then
-            iniset -sudo $config_file DEFAULT aaa_mode no-auth
-        fi
+        iniset -sudo $config_file DEFAULT aaa_mode $AAA_MODE
     fi
 
     if _vercmp $CONTRAIL_BRANCH "<" R4.0; then

--- a/devstack/lib/neutron_plugins/opencontrail
+++ b/devstack/lib/neutron_plugins/opencontrail
@@ -27,6 +27,16 @@ function neutron_plugin_configure_service() {
     local PY_PLUGIN_PATH=$(python -c "import neutron_plugin_contrail; print neutron_plugin_contrail.__path__[0]")
     iniset $NEUTRON_CONF quotas quota_driver neutron_plugin_contrail.plugins.opencontrail.quota.driver.QuotaDriver
     iniset $NEUTRON_CONF DEFAULT api_extensions_path extensions:$PY_PLUGIN_PATH/extensions
+    if [[ $AAA_MODE != 'no-auth' ]]; then
+        # Add Contrail middleware to set the authentication token in the
+        # request thread as it needed by VNC API client in the core driver
+        NEUTRON_API_PASTE_FILE=$NEUTRON_CONF_DIR/api-paste.ini
+        iniset $NEUTRON_API_PASTE_FILE filter:user_token paste.filter_factory neutron_plugin_contrail.plugins.opencontrail.neutron_middleware:token_factory
+        array=($(iniget_multiline $NEUTRON_API_PASTE_FILE composite:neutronapi_v2_0 keystone))
+        index=$(echo ${array[@]/extensions//} | cut -d/ -f1 | wc -w | tr -d ' ')
+        new_arr=( ${array[@]:0:$index} 'user_token' ${array[@]:$index} )
+        iniset $NEUTRON_API_PASTE_FILE composite:neutronapi_v2_0 keystone "$(echo ${new_arr[@]})"
+    fi
 }
 
 function neutron_plugin_setup_interface_driver() {

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -407,6 +407,12 @@ elif [[ "$1" == "stack" && "$2" == "post-config" ]]; then
             --oper add --linklocal_service_name metadata --linklocal_service_ip 169.254.169.254 \
             --linklocal_service_port 80 --ipfabric_service_ip $NOVA_SERVICE_HOST --ipfabric_service_port 8775 \
             || /bin/true    # Failure is not critical
+        if [[ $AAA_MODE != 'no-auth' ]]; then
+            echo y | python $CONTRAIL_DEST/controller/src/config/utils/rbacutil.py \
+                --server $SERVICE_HOST:8082 --os-username $CONTRAIL_ADMIN_USER --os-password $CONTRAIL_ADMIN_PASSWORD --os-tenant-name $CONTRAIL_ADMIN_PROJECT \
+                --name "default-global-system-config:default-api-access-list" --rule "* member:CRUD" --op add-rule \
+                || /bin/true    # Failure is not critical
+        fi
     fi
     if [[ "$Q_L3_ENABLED" == "True" ]]; then
         sudo /usr/share/contrail/provision_vgw_interface.py --oper create \

--- a/devstack/settings
+++ b/devstack/settings
@@ -60,8 +60,7 @@ VR_KMOD_OPTS=${VR_KMOD_OPTS:-"vr_flow_entries=4096 vr_oflow_entries=512 vr_bridg
 
 # Services configuration
 #-----------------------
-
-MULTI_TENANCY=${MULTI_TENANCY:-False}
+AAA_MODE=${AAA_MODE:-no-auth}
 
 USE_EXTERNAL_CASSANDRA=$(trueorfalse False USE_EXTERNAL_CASSANDRA)
 CASS_MAX_HEAP_SIZE=${CASS_MAX_HEAP_SIZE:-"500M"}


### PR DESCRIPTION
Since multi_tenancy knob was deprecated [1] by aaa_mode one when RBAC
feature was introduced, that patch updates devstack plugin.

[1] https://github.com/Juniper/contrail-controller/wiki/RBAC#aaa-mode